### PR TITLE
fix(manifest): remove alarms permissions since not used

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,7 +22,7 @@
     "permissions": [
     "scripting",
     "background",
-    "tabs", "alarms",
+    "tabs",
     "storage"
     ],
     "host_permissions": [ "<all_urls>"],


### PR DESCRIPTION
We are currently importing the alarms permission but its not used. This was reported by the chrome
app review team.

fixes #7